### PR TITLE
43 multiprocessing training

### DIFF
--- a/predictions.py
+++ b/predictions.py
@@ -133,12 +133,13 @@ def main():
     model_base_location = os.getcwd() + "/temp/"
     json_location = model_base_location
 
+    # get data and create inout sequences
+    download_new_file = True
+    if download_new_file:
+        pp.download_csv(url, csv_location)
+
     locations = True
     if not locations:
-        # get data and create inout sequences
-        download_new_file = True
-        if download_new_file:
-            pp.download_csv(url, csv_location)
         unique, counts = pp.process_csv(csv_location)
         data_array = pp.interpolate_cases(unique, counts)
         scaler = pp.create_scaler()
@@ -179,11 +180,6 @@ def main():
         plt.plot(prediction_dates, predictions)
         plt.show()
     else:
-        # get data and create inout sequences
-        download_new_file = True
-        if download_new_file:
-            pp.download_csv(url, csv_location)
-
         # create dictionaries of data needed for each location
         locations_dict = pp.process_csv_locations(csv_location)
         date_list, _ = pp.process_csv(csv_location)

--- a/predictions.py
+++ b/predictions.py
@@ -206,7 +206,9 @@ def main():
                 np.array(interpolated_dict[location][1]), scaler_dict[location]
             )
             train_window = 7  # 1 week
-            inout_locations[location] = pp.create_tensors(normalized_data[location], train_window)
+            inout_locations[location] = pp.create_tensors(
+                normalized_data[location], train_window
+            )
 
             # train model and make predictions for each location
             num_forecast = 7

--- a/predictions.py
+++ b/predictions.py
@@ -128,9 +128,9 @@ def convert_json(save_location, locations_dict, prediction_dates=[]):
 
 def main():
     url = "https://data.ontario.ca/dataset/f4112442-bdc8-45d2-be3c-12efae72fb27/resource/455fd63b-603d-4608-8216-7d8647f43350/download/conposcovidloc.csv"
-    csv_location = os.getcwd() + "/temp/conposcovidloc.csv"
-    model_location = os.getcwd() + "/temp/model.pt"
-    model_base_location = os.getcwd() + "/temp/"
+    csv_location = os.path.join(os.getcwd(), "temp/conposcovidloc.csv")
+    model_location = os.path.join(os.getcwd(), "temp/model.pt")
+    model_base_location = os.path.join(os.getcwd(), "temp/")
     json_location = model_base_location
 
     # get data and create inout sequences

--- a/predictions.py
+++ b/predictions.py
@@ -1,7 +1,6 @@
 import json
 import os
 from datetime import datetime, timedelta
-from time import sleep
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/predictions.py
+++ b/predictions.py
@@ -1,5 +1,6 @@
 import json
 import os
+import multiprocessing
 from datetime import datetime, timedelta
 
 import matplotlib.pyplot as plt
@@ -96,16 +97,15 @@ def predict(model, num_pred, train_data_normalized, train_window):
 
 def convert_json(save_location, locations_dict, prediction_dates=[]):
     new_dict = {}
-    for location in locations_dict:
-        current_loc = locations_dict[location]
-        for datenum, date in enumerate(current_loc[0]):
+    for location, data in locations_dict.items():
+        for datenum, date in enumerate(data["dates"]):
             is_pred = True if date in prediction_dates else False
             if date in new_dict:
                 new_dict[date].append(
                     {
                         "x": pp.coordinates[location]["x"],
                         "y": pp.coordinates[location]["y"],
-                        "value": current_loc[1][datenum],
+                        "value": data["cases"][datenum],
                         "loc": location,
                         "prediction": is_pred,
                     }
@@ -115,7 +115,7 @@ def convert_json(save_location, locations_dict, prediction_dates=[]):
                     {
                         "x": pp.coordinates[location]["x"],
                         "y": pp.coordinates[location]["y"],
-                        "value": current_loc[1][datenum],
+                        "value": data["cases"][datenum],
                         "loc": location,
                         "prediction": is_pred,
                     }
@@ -125,131 +125,115 @@ def convert_json(save_location, locations_dict, prediction_dates=[]):
         return json.dump(new_dict, f)
 
 
+def train(
+    location,
+    unique,
+    counts,
+    model_base_location,
+    date_list=None,
+    train_new_model=True,
+    train_window=7,
+    num_forecast=7,
+):
+    # pad with zeros for time series prediction
+    if date_list is not None:
+        inter_dates, inter_cases = pp.interpolate_cases(
+            unique, counts, zeros=True, end=str(date_list[-1])
+        )
+    else:
+        inter_dates, inter_cases = pp.interpolate_cases(unique, counts)
+
+    # create a scaler for this location and normalize the data
+    scaler = pp.create_scaler()
+    normalized = pp.normalize_data(np.array(inter_cases), scaler)
+    inout_seq = pp.create_tensors(normalized, train_window)
+
+    # train or load model
+    if train_new_model:
+        model = train_model(inout_seq)
+        torch.save(model, model_base_location + location + ".pt")
+    else:
+        model = torch.load(model_base_location + location + ".pt")
+
+    # make predictions
+    normalized_preds = predict(model, num_forecast, normalized, train_window)
+    predictions = pp.denormalize_data(normalized_preds, scaler)
+
+    # create date list for predictions
+    prediction_dates = pp.get_date_list(
+        start=str(datetime.strptime(inter_dates[-1], "%Y-%m-%d") + timedelta(days=1)),
+        end=str(
+            datetime.strptime(inter_dates[-1], "%Y-%m-%d")
+            + timedelta(days=num_forecast)
+        ),
+    )
+
+    # update case data with predictions
+    inter_dates = np.append(inter_dates, prediction_dates)
+    inter_cases = np.append(inter_cases, predictions)
+    inter_dates = inter_dates.tolist()
+    inter_cases = inter_cases.tolist()
+
+    return location, inter_dates, inter_cases, prediction_dates, predictions
+
+
 def main():
     url = "https://data.ontario.ca/dataset/f4112442-bdc8-45d2-be3c-12efae72fb27/resource/455fd63b-603d-4608-8216-7d8647f43350/download/conposcovidloc.csv"
     csv_location = os.path.join(os.getcwd(), "temp/conposcovidloc.csv")
-    model_location = os.path.join(os.getcwd(), "temp/model.pt")
     model_base_location = os.path.join(os.getcwd(), "temp/")
     json_location = model_base_location
 
     # get data and create inout sequences
-    download_new_file = True
+    download_new_file = False
     if download_new_file:
         pp.download_csv(url, csv_location)
 
     locations = True
     if not locations:
         unique, counts = pp.process_csv(csv_location)
-        data_array = pp.interpolate_cases(unique, counts)
-        scaler = pp.create_scaler()
-        normalized_data = pp.normalize_data(np.array(data_array[1]), scaler)
-        train_window = 7
-        inout_seq = pp.create_tensors(normalized_data, train_window)
-
-        # train model and make predictions
-        num_forecast = 7
-        train_new_model = True
-        if train_new_model:
-            model = train_model(inout_seq)
-            torch.save(model, model_location)
-        else:
-            model = torch.load(model_location)
-        normalized_preds = predict(model, num_forecast, normalized_data, train_window)
-        predictions = pp.denormalize_data(normalized_preds, scaler)
-        prediction_dates = pp.get_date_list(
-            start=str(
-                datetime.strptime(data_array[0][-1], "%Y-%m-%d") + timedelta(days=1)
-            ),
-            end=str(
-                datetime.strptime(data_array[0][-1], "%Y-%m-%d")
-                + timedelta(days=num_forecast)
-            ),
+        _, dates, cases, pred_dates, pred_cases = train(
+            location="model",
+            unique=unique,
+            counts=counts,
+            model_base_location=model_base_location,
         )
-
-        # update case data with predictions
-        data_array[0] = np.append(data_array[0], prediction_dates)
-        data_array[1] = np.append(data_array[1], predictions)
 
         # plot original and predictions
         plt.title("Predictions")
         plt.ylabel("Confirmed Cases")
         plt.grid(True)
         plt.autoscale(axis="x", tight=True)
-        plt.plot(data_array[0], data_array[1])
-        plt.plot(prediction_dates, predictions)
+        plt.plot(dates, cases)
+        plt.plot(pred_dates, pred_cases)
         plt.show()
     else:
         # create dictionaries of data needed for each location
         locations_dict = pp.process_csv_locations(csv_location)
         date_list, _ = pp.process_csv(csv_location)
         interpolated_dict = {}
-        scaler_dict = {}
-        normalized_data = {}
-        inout_locations = {}
-        for location in locations_dict:
-            # get unique element array and counts of elements array
-            unique = locations_dict[location][0]
-            counts = locations_dict[location][1]
-            # pad with zeros for time series prediction
-            interpolated_dict[location] = pp.interpolate_cases(
-                unique, counts, zeros=True, end=str(date_list[-1])
-            )
 
-            # create a scaler for this location and normalize the data
-            scaler_dict[location] = pp.create_scaler()
-            normalized_data[location] = pp.normalize_data(
-                np.array(interpolated_dict[location][1]), scaler_dict[location]
+        # train (or load) models for each location and get predictions
+        for location, (unique, counts) in locations_dict.items():
+            location, dates, cases, prediction_dates, _ = train(
+                location=location,
+                unique=unique,
+                counts=counts,
+                model_base_location=model_base_location,
+                date_list=date_list,
             )
-            train_window = 7  # 1 week
-            inout_locations[location] = pp.create_tensors(
-                normalized_data[location], train_window
-            )
+            interpolated_dict[location] = {}
+            interpolated_dict[location]["dates"] = dates
+            interpolated_dict[location]["cases"] = cases
 
-            # train model and make predictions for each location
-            num_forecast = 7
-            train_new_model = False
-            if train_new_model:
-                model = train_model(inout_locations[location])
-                torch.save(model, model_base_location + location + ".pt")
-            else:
-                model = torch.load(model_base_location + location + ".pt")
-
-            # make predictions
-            normalized_preds = predict(
-                model, num_forecast, normalized_data[location], train_window
-            )
-            predictions = pp.denormalize_data(normalized_preds, scaler_dict[location])
-            # create date list for predictions
-            prediction_dates = pp.get_date_list(
-                start=str(
-                    datetime.strptime(interpolated_dict[location][0][-1], "%Y-%m-%d")
-                    + timedelta(days=1)
-                ),
-                end=str(
-                    datetime.strptime(interpolated_dict[location][0][-1], "%Y-%m-%d")
-                    + timedelta(days=num_forecast)
-                ),
-            )
-
-            # update case data with predictions
-            interpolated_dict[location][0] = np.append(
-                interpolated_dict[location][0], prediction_dates
-            )
-            interpolated_dict[location][1] = np.append(
-                interpolated_dict[location][1], predictions
-            )
-
-            interpolated_dict[location][0] = interpolated_dict[location][0].tolist()
-            interpolated_dict[location][1] = interpolated_dict[location][1].tolist()
-
+        # convert and save predictions to json
         convert_json(json_location, interpolated_dict, prediction_dates)
 
         # plot actual cases and predictions
         plt.close()
         for location in interpolated_dict:
             plt.plot(
-                interpolated_dict[location][0],
-                interpolated_dict[location][1],
+                interpolated_dict[location]["dates"],
+                interpolated_dict[location]["cases"],
                 label=location,
             )
         plt.title("COVID-19 Cases Per Location")

--- a/predictions.py
+++ b/predictions.py
@@ -227,6 +227,7 @@ def main():
             )
             for location, (unique, counts) in locations_dict.items()
         ]
+        prediction_dates = []
         pool = torch.multiprocessing.Pool(multiprocessing.cpu_count() - 2)
         for location, dates, cases, prediction_dates, _ in pool.imap_unordered(
             _train, _inputs, chunksize=1


### PR DESCRIPTION
Added multiprocessing support for location training. The default number of processors is `multiprocessing.cpu_count() - 2`.

This PR also adds a argparse CLI for `predictions.py` to make it easier to run with different options and configurations. Here are some examples:
**Download new data and train new locations models**
```bash
python predictions.py --download_new_file true --locations true --train_new_model true 
```
**Train model with train_windows and number of forecast days as 6**
```bash
python --train_window 6 --num_forecast 6
```